### PR TITLE
Introduce Singleton Pattern to Tooltip Engine Classes

### DIFF
--- a/public/includes/Glossary_Tooltip_Engine.php
+++ b/public/includes/Glossary_Tooltip_Engine.php
@@ -11,6 +11,31 @@
  * @copyright 2015 GPL
  */
 class Glossary_Tooltip_Engine {
+	/**
+	 * The single instance of the class.
+	 *
+	 * @since 1.3.0
+	 */
+	protected static $instance = null;
+
+	/**
+	 * Main Glossary_Tooltip_Engine.
+	 *
+	 * Ensure only one instance of Glossary_Tooltip_Engine is loaded.
+	 *
+	 * @static
+	 *
+	 * @since 1.3.0
+	 *
+	 * @return Glossary_Tooltip_Engine - Main instance.
+	 */
+	public static function get_instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
 
   /**
    * Initialize the class with all the hooks
@@ -272,4 +297,17 @@ class Glossary_Tooltip_Engine {
 
 }
 
-new Glossary_Tooltip_Engine();
+/**
+ * Main instance of Glossary_Tooltip_Engine.
+ *
+ * Returns the main instance of Glossary_Tooltip_Engine to prevent the need to use globals.
+ *
+ * @since 1.3.0
+ *
+ * @return Glossary_Tooltip_Engine
+ */
+function Glossary_Tooltip_Engine() {
+	return Glossary_Tooltip_Engine::get_instance();
+}
+
+Glossary_Tooltip_Engine();

--- a/public/includes/Glossary_a2z_Archive.php
+++ b/public/includes/Glossary_a2z_Archive.php
@@ -12,6 +12,32 @@
  */
 class Glossary_a2z_Archive {
 
+	/**
+	 * The single instance of the class.
+	 *
+	 * @since 1.3.0
+	 */
+	protected static $instance = null;
+
+	/**
+	 * Main Glossary_a2z_Archive.
+	 *
+	 * Ensure only one instance of Glossary_a2z_Archive is loaded.
+	 *
+	 * @static
+	 *
+	 * @since 1.3.0
+	 *
+	 * @return Glossary_a2z_Archive - Main instance.
+	 */
+	public static function get_instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
   /**
    * Initialize the plugin by setting localization and loading public scripts
    * and styles.
@@ -25,7 +51,7 @@ class Glossary_a2z_Archive {
 
   /**
    * Add our value
-   * 
+   *
    * @param array $query_vars
    * @return array
    */
@@ -36,7 +62,7 @@ class Glossary_a2z_Archive {
 
   /**
    * Check our value
-   * 
+   *
    * @global object $wp_query
    * @param object $query
    */
@@ -50,7 +76,7 @@ class Glossary_a2z_Archive {
 
   /**
    * Alter the SQL
-   * 
+   *
    * @global object $wp_query
    * @global object $wpdb
    * @param string $where
@@ -65,7 +91,7 @@ class Glossary_a2z_Archive {
 
   /**
    * Alter the SQL
-   * 
+   *
    * @global object $wpdb
    * @param string $orderby
    * @return string
@@ -80,4 +106,17 @@ class Glossary_a2z_Archive {
 
 }
 
-new Glossary_a2z_Archive();
+/**
+ * Main instance of Glossary_a2z_Archive.
+ *
+ * Returns the main instance of Glossary_a2z_Archive to prevent the need to use globals.
+ *
+ * @since 1.3.0
+ *
+ * @return Glossary_a2z_Archive
+ */
+function Glossary_a2z_Archive() {
+	return Glossary_a2z_Archive::get_instance();
+}
+
+Glossary_a2z_Archive();


### PR DESCRIPTION
Currently, the `Glossary_Tooltip_Engine` class is not saved anywhere when created. This is problematic if a theme or plugin wants to remove, add, or change any action of filter hooks within that class.

A great breakdown on why this is problematic [exists on Stack Exchange](http://wordpress.stackexchange.com/a/36110).

This pull request fixes this issue by implementing the Singleton pattern within the `Glossary_Tooltip_Engine` and `Glossary_a2z_Archive` classes.