### PR TITLE
Per post override

### DIFF
--- a/public/class-glossary.php
+++ b/public/class-glossary.php
@@ -238,7 +238,7 @@ class Glossary {
 	 * @param WP_Post $post WP_Post object.
 	 */
 	function save_post( $post_id, $post ) {
-		if ( ! in_array( $post->post_type, $this->settings['posttypes'], true ) ) {
+		if ( ! in_array( $post->post_type, (array) $this->settings['posttypes'], true ) ) {
 			return;
 		}
 

--- a/public/class-glossary.php
+++ b/public/class-glossary.php
@@ -92,6 +92,9 @@ class Glossary {
     }
 
     add_filter( 'glossary-themes-url', array( $this, 'add_glossary_url' ) );
+
+		add_action( 'add_meta_boxes', array( $this, 'add_meta_boxes' ) );
+		add_action( 'save_post', array( $this, 'save_post' ), 10, 2 );
   }
 
   /**
@@ -169,7 +172,7 @@ class Glossary {
 
   /**
    * Add the path to the themes
-   * 
+   *
    * @param array $themes
    * @return array
    */
@@ -182,7 +185,7 @@ class Glossary {
 
   /**
    * Hide the taxonomy on the frontend
-   * 
+   *
    * @param object $query
    * @return object
    */
@@ -196,4 +199,67 @@ class Glossary {
     }
   }
 
+	/**
+	 * Add action hook for Glossary disable checkbox field on supported post types.
+	 *
+	 * @param string $post_type Post type.
+	 */
+	function add_meta_boxes( $post_type ) {
+  		if ( ! in_array( $post_type, $this->settings['posttypes'], true ) ) {
+  			return;
+		}
+
+		add_action( 'post_submitbox_misc_actions', array( $this, 'post_submitbox_misc_actions' ) );
+	}
+
+	/**
+	 * Add a checkbox for disabling Glossary term linking on a page.
+	 */
+	function post_submitbox_misc_actions() {
+		$screen = get_current_screen();
+		$post_id = 0;
+
+		if ( 'add' !== $screen->action ) {
+			$post_id = (int) wp_unslash( $_GET['post'] );
+		}
+
+		?>
+		<div class="misc-pub-section glossary-disable">
+			<?php wp_nonce_field( '_glossary_exclude_nonce', '_glossary_exclude_noncename' ); ?>
+			<span><?php _e( 'Disable Glossary linking' ); ?>:</span>&nbsp;<input type="checkbox" name="_glossary_disable" id="_glossary_disable" <?php checked( (bool) get_post_meta( $post_id, '_glossary_disable', true ) ); ?> />
+		</div>
+		<?php
+	}
+
+	/**
+	 * Save the Glossary disable post meta for supported post types.
+	 *
+	 * @param int $post_id Post ID.
+	 * @param WP_Post $post WP_Post object.
+	 */
+	function save_post( $post_id, $post ) {
+		if ( ! in_array( $post->post_type, $this->settings['posttypes'], true ) ) {
+			return;
+		}
+
+		//Skip revisions and autosaves
+		if ( wp_is_post_revision( $post_id ) || ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) || ( defined( 'DOING_AJAX' ) && DOING_AJAX ) ) {
+			return;
+		}
+
+		//Users should have the ability to edit.
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+			return;
+		}
+
+		if ( isset( $_POST['_glossary_exclude_noncename'] ) && wp_verify_nonce( $_POST['_glossary_exclude_noncename'], '_glossary_exclude_nonce' ) ) {
+			$disable_glossary = (bool) $_POST['_glossary_disable'];
+
+			if ( $disable_glossary ) {
+				update_post_meta( $post_id, '_glossary_disable', 1 );
+			} else {
+				delete_post_meta( $post_id, '_glossary_disable' );
+			}
+		}
+	}
 }

--- a/public/includes/Glossary_Tooltip_Engine.php
+++ b/public/includes/Glossary_Tooltip_Engine.php
@@ -24,15 +24,23 @@ class Glossary_Tooltip_Engine {
     add_action( 'genesis_entry_content', array( $this, 'genesis_content' ), 9 );
   }
 
-  /**
-   *
-   * The magic function that add the glossary terms to your content
-   *
-   * @global object $post
-   * @param string $text
-   * @return string
-   */
-  public function glossary_auto_link( $text ) {
+	/**
+	 *
+	 * The magic function that add the glossary terms to your content
+	 *
+	 * @global object $post
+	 * @param string $text
+	 * @return string
+	 */
+	public function glossary_auto_link( $text ) {
+		$queried_object = get_queried_object();
+
+		if ( $this->g_is_singular() && is_a( $queried_object, 'WP_Post' ) ) {
+			if ( get_post_meta( $queried_object->ID, '_glossary_disable', true ) ) {
+				return $text;
+			}
+		}
+
     if (
 		$this->g_is_singular() ||
 		$this->g_is_home() ||


### PR DESCRIPTION
Currently, there is no fine grained control over which posts receive Glossary auto-linking: it is all or nothing.

This pull request adds a checkbox above the publish button to disable term auto-linking on that post.

We have a use case where it is not desired for the home page to be riddled with definition links.